### PR TITLE
Use resource_group filter

### DIFF
--- a/app/api/actions/equipment.js
+++ b/app/api/actions/equipment.js
@@ -4,7 +4,7 @@ import createApiAction from './createApiAction';
 function fetchEquipment() {
   return createApiAction({
     endpoint: 'equipment',
-    params: { pageSize: 100 },
+    params: { pageSize: 100, resource_group: 'kanslia' },
     method: 'GET',
     type: 'EQUIPMENT',
     options: { schema: schemas.paginatedEquipmentSchema },

--- a/app/api/actions/equipment.spec.js
+++ b/app/api/actions/equipment.spec.js
@@ -11,7 +11,7 @@ describe('api/actions/equipment', () => {
       args: [],
       tests: {
         method: 'GET',
-        endpoint: buildAPIUrl('equipment', { pageSize: 100 }),
+        endpoint: buildAPIUrl('equipment', { pageSize: 100, resource_group: 'kanslia' }),
         request: {
           type: types.EQUIPMENT_GET_REQUEST,
         },

--- a/app/api/actions/resources.js
+++ b/app/api/actions/resources.js
@@ -20,7 +20,7 @@ function fetchResource(id, params = {}) {
 
 function fetchResources(params = {}) {
   const defaultParams = {
-    group: 'kanslia',
+    resource_group: 'kanslia',
     pageSize: 100,
   };
   return createApiAction({

--- a/app/api/actions/resources.spec.js
+++ b/app/api/actions/resources.spec.js
@@ -66,7 +66,7 @@ describe('api/actions/resources', () => {
   });
 
   describe('fetchResources', () => {
-    const params = getParamsWithTimes({ group: 'kanslia', pageSize: 100 });
+    const params = getParamsWithTimes({ resource_group: 'kanslia', pageSize: 100 });
     createApiTest({
       name: 'fetchResources',
       action: fetchResources,

--- a/app/api/actions/types.js
+++ b/app/api/actions/types.js
@@ -4,7 +4,7 @@ import createApiAction from './createApiAction';
 function fetchTypes() {
   return createApiAction({
     endpoint: 'type',
-    params: { pageSize: 100 },
+    params: { pageSize: 100, resource_group: 'kanslia' },
     method: 'GET',
     type: 'TYPES',
     options: { schema: schemas.paginatedTypesSchema },

--- a/app/api/actions/types.spec.js
+++ b/app/api/actions/types.spec.js
@@ -11,7 +11,7 @@ describe('api/actions/types', () => {
       args: [],
       tests: {
         method: 'GET',
-        endpoint: buildAPIUrl('type', { pageSize: 100 }),
+        endpoint: buildAPIUrl('type', { pageSize: 100, resource_group: 'kanslia' }),
         request: {
           type: types.TYPES_GET_REQUEST,
         },

--- a/app/api/actions/units.js
+++ b/app/api/actions/units.js
@@ -4,7 +4,7 @@ import createApiAction from './createApiAction';
 function fetchUnits() {
   return createApiAction({
     endpoint: 'unit',
-    params: { pageSize: 100 },
+    params: { pageSize: 100, resource_group: 'kanslia' },
     method: 'GET',
     type: 'UNITS',
     options: { schema: schemas.paginatedUnitsSchema },

--- a/app/api/actions/units.spec.js
+++ b/app/api/actions/units.spec.js
@@ -11,7 +11,7 @@ describe('api/actions/units', () => {
       args: [],
       tests: {
         method: 'GET',
-        endpoint: buildAPIUrl('unit', { pageSize: 100 }),
+        endpoint: buildAPIUrl('unit', { pageSize: 100, resource_group: 'kanslia' }),
         request: {
           type: types.UNITS_GET_REQUEST,
         },


### PR DESCRIPTION
Added to equipment, types, and units. Renamed in resources from group to
resource_group.

Closes #136.