### PR TITLE
Search reservations page

### DIFF
--- a/app/actions/uiActions.js
+++ b/app/actions/uiActions.js
@@ -1,6 +1,7 @@
 import { createActions } from 'redux-actions';
 
 export default createActions(
+  'CHANGE_RESERVATION_SEARCH_FILTERS',
   'CHANGE_RESOURCE_SEARCH_FILTERS',
   'HIDE_RESERVATION_CANCEL_MODAL',
   'HIDE_RESERVATION_INFO_MODAL',

--- a/app/api/actions/reservations.js
+++ b/app/api/actions/reservations.js
@@ -35,9 +35,13 @@ function fetchReservation(id) {
 }
 
 function fetchReservations(params = {}) {
+  const defaultParams = {
+    resource_group: 'kanslia',
+    pageSize: 100,
+  };
   return createApiAction({
     endpoint: 'reservation',
-    params: Object.assign({}, params, { pageSize: 100 }),
+    params: { ...defaultParams, ...params },
     method: 'GET',
     type: 'RESERVATIONS',
     options: { schema: schemas.paginatedReservationsSchema },

--- a/app/api/actions/reservations.spec.js
+++ b/app/api/actions/reservations.spec.js
@@ -87,7 +87,7 @@ describe('api/actions/reservations', () => {
       args: [],
       tests: {
         method: 'GET',
-        endpoint: buildAPIUrl('reservation', { pageSize: 100 }),
+        endpoint: buildAPIUrl('reservation', { pageSize: 100, resource_group: 'kanslia' }),
         request: {
           type: types.RESERVATIONS_GET_REQUEST,
         },

--- a/app/api/actions/resources.js
+++ b/app/api/actions/resources.js
@@ -18,14 +18,18 @@ function fetchResource(id, params = {}) {
   });
 }
 
-function fetchResources(params = {}) {
+function fetchResources(params = {}, times = true) {
   const defaultParams = {
     resource_group: 'kanslia',
     pageSize: 100,
   };
+  const paramsWithTimes = times ? getParamsWithTimes(params) : {};
   return createApiAction({
     endpoint: 'resource',
-    params: { ...defaultParams, ...getParamsWithTimes(params) },
+    params: {
+      ...defaultParams,
+      ...paramsWithTimes,
+    },
     method: 'GET',
     type: 'RESOURCES',
     options: { schema: schemas.paginatedResourcesSchema },

--- a/app/api/actions/resources.spec.js
+++ b/app/api/actions/resources.spec.js
@@ -66,24 +66,48 @@ describe('api/actions/resources', () => {
   });
 
   describe('fetchResources', () => {
-    const params = getParamsWithTimes({ resource_group: 'kanslia', pageSize: 100 });
-    createApiTest({
-      name: 'fetchResources',
-      action: fetchResources,
-      args: [],
-      tests: {
-        method: 'GET',
-        endpoint: buildAPIUrl('resource', params),
-        request: {
-          type: types.RESOURCES_GET_REQUEST,
+    describe('with times', () => {
+      const params = getParamsWithTimes({ resource_group: 'kanslia', pageSize: 100 });
+      createApiTest({
+        name: 'fetchResources',
+        action: fetchResources,
+        args: [],
+        tests: {
+          method: 'GET',
+          endpoint: buildAPIUrl('resource', params),
+          request: {
+            type: types.RESOURCES_GET_REQUEST,
+          },
+          success: {
+            type: types.RESOURCES_GET_SUCCESS,
+          },
+          error: {
+            type: types.RESOURCES_GET_ERROR,
+          },
         },
-        success: {
-          type: types.RESOURCES_GET_SUCCESS,
+      });
+    });
+
+    describe('without times', () => {
+      const params = { resource_group: 'kanslia', pageSize: 100 };
+      createApiTest({
+        name: 'fetchResources',
+        action: fetchResources,
+        args: [{}, false],
+        tests: {
+          method: 'GET',
+          endpoint: buildAPIUrl('resource', params),
+          request: {
+            type: types.RESOURCES_GET_REQUEST,
+          },
+          success: {
+            type: types.RESOURCES_GET_SUCCESS,
+          },
+          error: {
+            type: types.RESOURCES_GET_ERROR,
+          },
         },
-        error: {
-          type: types.RESOURCES_GET_ERROR,
-        },
-      },
+      });
     });
   });
 

--- a/app/api/selectors/index.js
+++ b/app/api/selectors/index.js
@@ -1,6 +1,14 @@
 import actionTypes from '../actionTypes';
 import createRequestIsActiveSelector from './createRequestIsActiveSelector';
 
+const reservationDeleteIsActiveSelector = createRequestIsActiveSelector(
+  actionTypes.RESERVATION_DELETE_REQUEST
+);
+
+const reservationsGetIsActiveSelector = createRequestIsActiveSelector(
+  actionTypes.RESERVATIONS_GET_REQUEST
+);
+
 const resourceGetIsActiveSelector = createRequestIsActiveSelector(
   actionTypes.RESOURCE_GET_REQUEST
 );
@@ -17,12 +25,9 @@ const unitsGetIsActiveSelector = createRequestIsActiveSelector(
   actionTypes.UNITS_GET_REQUEST
 );
 
-const reservationDeleteIsActiveSelector = createRequestIsActiveSelector(
-  actionTypes.RESERVATION_DELETE_REQUEST
-);
-
 export {
   reservationDeleteIsActiveSelector,
+  reservationsGetIsActiveSelector,
   resourceGetIsActiveSelector,
   resourcePostIsActiveSelector,
   resourcesGetIsActiveSelector,

--- a/app/pages/AppContainer.js
+++ b/app/pages/AppContainer.js
@@ -5,7 +5,7 @@ import Loader from 'react-loader';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 
-import { fetchEquipment, fetchTypes, fetchUnits } from 'api/actions';
+import { fetchEquipment, fetchResources, fetchTypes, fetchUnits } from 'api/actions';
 import { fetchAuthState } from 'auth/actions';
 import ReservationCancelModal from 'shared/modals/reservation-cancel';
 import ReservationInfoModal from 'shared/modals/reservation-info';
@@ -19,6 +19,7 @@ export class UnconnectedAppContainer extends Component {
     this.props.fetchUnits();
     this.props.fetchTypes();
     this.props.fetchEquipment();
+    this.props.fetchResources({}, false);
   }
 
   componentWillReceiveProps(props) {
@@ -51,11 +52,18 @@ UnconnectedAppContainer.propTypes = {
   isAuthFetched: PropTypes.bool.isRequired,
   isLoggedIn: PropTypes.bool.isRequired,
   fetchEquipment: PropTypes.func.isRequired,
+  fetchResources: PropTypes.func.isRequired,
   fetchTypes: PropTypes.func.isRequired,
   fetchUnits: PropTypes.func.isRequired,
 };
 
-const actions = { fetchAuthState, fetchEquipment, fetchTypes, fetchUnits };
+const actions = {
+  fetchAuthState,
+  fetchEquipment,
+  fetchResources,
+  fetchTypes,
+  fetchUnits,
+};
 
 export const selector = createStructuredSelector({
   isAuthFetched: state => state.auth.isFetched,

--- a/app/pages/AppContainer.spec.js
+++ b/app/pages/AppContainer.spec.js
@@ -17,6 +17,7 @@ describe('pages/AppContainer', () => {
     const defaults = {
       fetchAuthState: () => null,
       fetchEquipment: () => null,
+      fetchResources: () => null,
       fetchTypes: () => null,
       fetchUnits: () => null,
       isAuthFetched: true,
@@ -102,6 +103,14 @@ describe('pages/AppContainer', () => {
       const instance = getWrapper({ fetchEquipment }).instance();
       instance.componentDidMount();
       expect(fetchEquipment.callCount).to.equal(1);
+    });
+
+    it('fetches resources with param times = false', () => {
+      const fetchResources = simple.mock();
+      const instance = getWrapper({ fetchResources }).instance();
+      instance.componentDidMount();
+      expect(fetchResources.callCount).to.equal(1);
+      expect(fetchResources.lastCall.args).to.deep.equal([{}, false]);
     });
   });
 

--- a/app/pages/pages.less
+++ b/app/pages/pages.less
@@ -1,2 +1,3 @@
+@import './reservationSearch/reservation-search-page';
 @import './resource/resource-page';
 @import './search/search-page';

--- a/app/pages/pages.less
+++ b/app/pages/pages.less
@@ -1,3 +1,14 @@
 @import './reservationSearch/reservation-search-page';
 @import './resource/resource-page';
 @import './search/search-page';
+
+.search-results-count {
+  text-align: center;
+  margin-bottom: 20px;
+  padding: 10px;
+  background-color: @background-gray;
+}
+
+.resource-daily-report-button {
+  margin-top: 10px;
+}

--- a/app/pages/reservationSearch/ReservationSearchPageContainer.js
+++ b/app/pages/reservationSearch/ReservationSearchPageContainer.js
@@ -104,15 +104,17 @@ export class UnconnectedReservationSearchPageContainer extends Component {
           onChange={changeFilters}
           units={units}
         />
-        <Loader loaded={!isFetching}>
-          <div className="search-results-count">
-            <span>{searchResultsText} </span>
-            <Link to={PATH}>Tyhjennä haku.</Link>
-          </div>
-          {reservationGroups.map(group =>
-            <DayReservations key={group.day} {...group} />
-          )}
-        </Loader>
+        <div className="search-results-container">
+          <Loader loaded={!isFetching}>
+            <div className="search-results-count">
+              <span>{searchResultsText} </span>
+              <Link to={PATH}>Tyhjennä haku.</Link>
+            </div>
+            {reservationGroups.map(group =>
+              <DayReservations key={group.day} {...group} />
+            )}
+          </Loader>
+        </div>
       </div>
     );
   }

--- a/app/pages/reservationSearch/ReservationSearchPageContainer.js
+++ b/app/pages/reservationSearch/ReservationSearchPageContainer.js
@@ -1,20 +1,137 @@
-import React, { Component } from 'react';
+import { camelizeKeys, decamelizeKeys } from 'humps';
+import debounce from 'lodash/debounce';
+import isEmpty from 'lodash/isEmpty';
+import isEqual from 'lodash/isEqual';
+import omitBy from 'lodash/omitBy';
+import queryString from 'query-string';
+import React, { Component, PropTypes } from 'react';
+import Loader from 'react-loader';
 import { connect } from 'react-redux';
+import { browserHistory, Link } from 'react-router';
+
+import uiActions from 'actions/uiActions';
+import { fetchReservations } from 'api/actions';
+import DayReservations from './day-reservations';
+import selector from './reservationSearchPageSelector';
+import ReservationSearchControls from './reservation-search-controls';
+
+const PATH = '/reservations';
+
+function getUrl(filters) {
+  const cleaned = omitBy(filters, value => value === '');
+  const decamelized = decamelizeKeys(cleaned);
+  const urlParams = queryString.stringify(decamelized);
+  return `${PATH}?${urlParams}`;
+}
+
+export function parseUrlFilters(queryParams) {
+  return camelizeKeys(queryParams);
+}
 
 export class UnconnectedReservationSearchPageContainer extends Component {
+  static propTypes = {
+    changeFilters: PropTypes.func.isRequired,
+    fetchReservations: PropTypes.func.isRequired,
+    isFetching: PropTypes.bool.isRequired,
+    location: PropTypes.shape({ query: PropTypes.object }).isRequired,
+    reservationGroups: PropTypes.array.isRequired,
+    resultsCount: PropTypes.number.isRequired,
+    searchFilters: PropTypes.object.isRequired,
+    units: PropTypes.object.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+    this.throttledFetchAndChangeUrl = debounce(
+      this.fetchAndChangeUrl,
+      500,
+      { leading: false }
+    );
+  }
+
+  componentDidMount() {
+    const urlFilters = parseUrlFilters({ ...this.props.location.query });
+    if (isEmpty(urlFilters)) {
+      this.fetch(this.props.searchFilters);
+    } else {
+      this.props.changeFilters(urlFilters);
+    }
+  }
+
   componentWillUpdate(nextProps) {
-    console.log(nextProps);
+    if (!isEqual(this.props.searchFilters, nextProps.searchFilters)) {
+      if (this.shouldThrottle(nextProps)) {
+        this.throttledFetchAndChangeUrl(nextProps.searchFilters);
+      } else {
+        this.fetchAndChangeUrl(nextProps.searchFilters);
+      }
+    }
+  }
+
+  fetch(filters) {
+    const decamelized = decamelizeKeys(filters);
+    this.props.fetchReservations(decamelized);
+  }
+
+  fetchAndChangeUrl(filters) {
+    this.fetch(filters);
+    browserHistory.replace(getUrl(filters));
+  }
+
+  shouldThrottle(nextProps) {
+    const throttleFilters = [
+      'eventSubject',
+      'hostName',
+      'reserverName',
+      'resourceName',
+    ];
+    for (const filter of throttleFilters) {
+      const changed = !isEqual(
+        this.props.searchFilters[filter],
+        nextProps.searchFilters[filter]
+      );
+      if (changed) return true;
+    }
+    return false;
   }
 
   render() {
+    const {
+      changeFilters,
+      isFetching,
+      reservationGroups,
+      resultsCount,
+      searchFilters,
+      units,
+    } = this.props;
+    const searchResultsText = resultsCount === 1 ?
+      `Löytyi ${resultsCount} hakuehdot täyttävä varaus.` :
+      `Löytyi ${resultsCount} hakuehdot täyttävää varausta.`;
     return (
       <div className="reservation-search-page">
         <h1>Varaukset</h1>
+        <ReservationSearchControls
+          values={searchFilters}
+          onChange={changeFilters}
+          units={units}
+        />
+        <Loader loaded={!isFetching}>
+          <div className="search-results-count">
+            <span>{searchResultsText} </span>
+            <Link to={PATH}>Tyhjennä haku.</Link>
+          </div>
+          {reservationGroups.map(group =>
+            <DayReservations key={group.day} {...group} />
+          )}
+        </Loader>
       </div>
     );
   }
 }
 
-UnconnectedReservationSearchPageContainer.propTypes = {};
+const actions = {
+  changeFilters: uiActions.changeReservationSearchFilters,
+  fetchReservations,
+};
 
-export default connect(null)(UnconnectedReservationSearchPageContainer);
+export default connect(selector, actions)(UnconnectedReservationSearchPageContainer);

--- a/app/pages/reservationSearch/ReservationSearchPageContainer.js
+++ b/app/pages/reservationSearch/ReservationSearchPageContainer.js
@@ -1,6 +1,5 @@
-import { camelizeKeys, decamelizeKeys } from 'humps';
+import { decamelizeKeys } from 'humps';
 import debounce from 'lodash/debounce';
-import isEmpty from 'lodash/isEmpty';
 import isEqual from 'lodash/isEqual';
 import omitBy from 'lodash/omitBy';
 import queryString from 'query-string';
@@ -24,16 +23,11 @@ function getUrl(filters) {
   return `${PATH}?${urlParams}`;
 }
 
-export function parseUrlFilters(queryParams) {
-  return camelizeKeys(queryParams);
-}
-
 export class UnconnectedReservationSearchPageContainer extends Component {
   static propTypes = {
     changeFilters: PropTypes.func.isRequired,
     fetchReservations: PropTypes.func.isRequired,
     isFetching: PropTypes.bool.isRequired,
-    location: PropTypes.shape({ query: PropTypes.object }).isRequired,
     reservationGroups: PropTypes.array.isRequired,
     resultsCount: PropTypes.number.isRequired,
     searchFilters: PropTypes.object.isRequired,
@@ -50,12 +44,7 @@ export class UnconnectedReservationSearchPageContainer extends Component {
   }
 
   componentDidMount() {
-    const urlFilters = parseUrlFilters({ ...this.props.location.query });
-    if (isEmpty(urlFilters)) {
-      this.fetch(this.props.searchFilters);
-    } else {
-      this.props.changeFilters(urlFilters);
-    }
+    this.fetch(this.props.searchFilters);
   }
 
   componentWillUpdate(nextProps) {

--- a/app/pages/reservationSearch/ReservationSearchPageContainer.js
+++ b/app/pages/reservationSearch/ReservationSearchPageContainer.js
@@ -1,0 +1,20 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+export class UnconnectedReservationSearchPageContainer extends Component {
+  componentWillUpdate(nextProps) {
+    console.log(nextProps);
+  }
+
+  render() {
+    return (
+      <div className="reservation-search-page">
+        <h1>Varaukset</h1>
+      </div>
+    );
+  }
+}
+
+UnconnectedReservationSearchPageContainer.propTypes = {};
+
+export default connect(null)(UnconnectedReservationSearchPageContainer);

--- a/app/pages/reservationSearch/ReservationSearchPageContainer.spec.js
+++ b/app/pages/reservationSearch/ReservationSearchPageContainer.spec.js
@@ -1,0 +1,305 @@
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import { camelizeKeys, decamelizeKeys } from 'humps';
+import moment from 'moment';
+import queryString from 'query-string';
+import React from 'react';
+import Loader from 'react-loader';
+import { browserHistory, Link } from 'react-router';
+import simple from 'simple-mock';
+
+import DayReservation from './day-reservations';
+import {
+  parseUrlFilters,
+  UnconnectedReservationSearchPageContainer as ReservationSearchPageContainer,
+} from './ReservationSearchPageContainer';
+import ReservationSearchControls from './reservation-search-controls';
+
+describe('pages/search/ReservationSearchPageContainer', () => {
+  const searchFilters = {
+    end: '2016-12-12',
+    eventSubject: '',
+    hasCatering: '',
+    hasEquipment: '',
+    hostName: '',
+    isFavoriteResource: '',
+    isOwn: '',
+    reserverName: '',
+    resourceName: '',
+    start: '2016-11-12',
+    unit: '',
+  };
+  const defaultProps = {
+    changeFilters: () => null,
+    fetchReservations: () => null,
+    isFetching: false,
+    location: { query: {} },
+    reservationGroups: [
+      { day: moment('2016-11-12'), reservations: [1, 2] },
+    ],
+    resultsCount: 0,
+    searchFilters,
+    units: { 125: {} },
+  };
+
+  function getWrapper(props) {
+    return shallow(<ReservationSearchPageContainer {...defaultProps} {...props} />);
+  }
+
+  function getResultsCountWrapper(props) {
+    return getWrapper(props).find('.search-results-count');
+  }
+
+  describe('render', () => {
+    describe('when reservations are fetched', () => {
+      let wrapper;
+      const isFetching = true;
+      const reservations = [
+        { id: 1, name: { fi: 'Varaus 1' } },
+        { id: 2, name: { fi: 'Varaus 2' } },
+      ];
+
+      before(() => {
+        wrapper = getWrapper({ isFetching, reservations });
+      });
+
+      it('renders a header with correct text', () => {
+        const header = wrapper.find('h1');
+        expect(header.length).to.equal(1);
+        expect(header.text()).to.equal('Varaukset');
+      });
+
+      it('renders ReservationSearchControls with correct props', () => {
+        const searchControls = wrapper.find(ReservationSearchControls);
+        expect(searchControls).to.have.length(1);
+        expect(searchControls.prop('values')).to.deep.equal(defaultProps.searchFilters);
+        expect(searchControls.prop('units')).to.deep.equal(defaultProps.units);
+        expect(searchControls.prop('onChange')).to.be.a('function');
+      });
+
+      it('renders DayReservations with correct props', () => {
+        const dayReservations = wrapper.find(DayReservation);
+        expect(dayReservations).to.have.length(1);
+
+        const dayReservation = dayReservations.at(0);
+        const group = defaultProps.reservationGroups[0];
+        expect(dayReservation.prop('day')).to.equal(group.day);
+        expect(dayReservation.prop('reservations')).to.equal(group.reservations);
+      });
+
+      describe('results count', () => {
+        it('renders correct text if results is 0', () => {
+          const resultsCount = getResultsCountWrapper();
+          expect(resultsCount.text()).to.contain('Löytyi 0 hakuehdot täyttävää varausta');
+        });
+
+        it('renders correct text if results is 1', () => {
+          const resultsCount = getResultsCountWrapper({ resultsCount: 1 });
+          expect(resultsCount.text()).to.contain('Löytyi 1 hakuehdot täyttävä varaus');
+        });
+
+        it('renders correct text if results is greater than 1', () => {
+          const resultsCount = getResultsCountWrapper({ resultsCount: 4 });
+          expect(resultsCount.text()).to.contain('Löytyi 4 hakuehdot täyttävää varausta');
+        });
+
+        it('renders a Link with correct props for clearing search results', () => {
+          const resultsCount = getResultsCountWrapper();
+          const link = resultsCount.find(Link);
+          expect(link.prop('to')).to.equal('/reservations');
+          expect(link.prop('children')).to.equal('Tyhjennä haku.');
+        });
+      });
+    });
+
+    describe('when reservations are not fetched', () => {
+      let wrapper;
+      const isFetching = false;
+      const reservationGroups = [];
+
+      before(() => {
+        wrapper = getWrapper({ isFetching, reservationGroups });
+      });
+
+      it('renders a Loader', () => {
+        const loader = wrapper.find(Loader);
+        expect(loader).to.have.length(1);
+      });
+
+      it('renders ReservationSearchControls with correct props', () => {
+        const searchControls = wrapper.find(ReservationSearchControls);
+        expect(searchControls).to.have.length(1);
+        expect(searchControls.prop('values')).to.deep.equal(defaultProps.searchFilters);
+        expect(searchControls.prop('units')).to.deep.equal(defaultProps.units);
+        expect(searchControls.prop('onChange')).to.be.a('function');
+      });
+    });
+  });
+
+  describe('componentDidMount', () => {
+    let changeFilters;
+    let fetchReservations;
+
+    beforeEach(() => {
+      changeFilters = simple.mock();
+      fetchReservations = simple.mock();
+    });
+
+    afterEach(() => {
+      simple.restore();
+    });
+
+    function callComponentDidMount(query) {
+      const props = {
+        changeFilters,
+        fetchReservations,
+        location: { query },
+      };
+      const instance = getWrapper(props).instance();
+      instance.componentDidMount();
+    }
+
+    describe('when no query params in url', () => {
+      const query = {};
+
+      beforeEach(() => {
+        callComponentDidMount(query);
+      });
+
+      it('fetches reservations using decamelized filters', () => {
+        expect(fetchReservations.callCount).to.equal(1);
+        const expectedArg = decamelizeKeys(searchFilters);
+        expect(fetchReservations.lastCall.arg).to.deep.equal(expectedArg);
+      });
+
+      it('does not change filters', () => {
+        expect(changeFilters.callCount).to.equal(0);
+      });
+    });
+
+    describe('when query params in url', () => {
+      it('changes filters using camelized query params', () => {
+        const query = { is_favorite_resource: 'true' };
+        callComponentDidMount(query);
+        expect(changeFilters.callCount).to.equal(1);
+        const expectedArg = camelizeKeys(query);
+        expect(changeFilters.lastCall.arg).to.deep.equal(expectedArg);
+      });
+
+      it('does not fetch reservations', () => {
+        const query = { is_favorite_resource: 'true' };
+        callComponentDidMount(query);
+        expect(fetchReservations.callCount).to.equal(0);
+      });
+    });
+  });
+
+  describe('componentWillUpdate', () => {
+    let instance;
+    let fetchMock;
+    let throttledFetchMock;
+
+    beforeEach(() => {
+      instance = getWrapper({ searchFilters }).instance();
+      fetchMock = simple.mock(instance, 'fetchAndChangeUrl');
+      throttledFetchMock = simple.mock(instance, 'throttledFetchAndChangeUrl');
+    });
+
+    afterEach(() => {
+      simple.restore();
+    });
+
+    describe('when searchFilters prop changes', () => {
+      it('calls fetchAndChangeUrl with search filters', () => {
+        const nextProps = {
+          searchFilters: {
+            ...searchFilters,
+            start: '2016-12-13',
+          },
+        };
+        instance.componentWillUpdate(nextProps);
+        expect(fetchMock.callCount).to.equal(1);
+        expect(fetchMock.lastCall.arg).to.deep.equal(nextProps.searchFilters);
+        expect(throttledFetchMock.callCount).to.equal(0);
+      });
+
+      it('uses throttledFetch when text field changes', () => {
+        const nextProps = {
+          searchFilters: {
+            ...searchFilters,
+            eventSubject: 'Meeting',
+          },
+        };
+        instance.componentWillUpdate(nextProps);
+        expect(throttledFetchMock.callCount).to.equal(1);
+        expect(throttledFetchMock.lastCall.arg).to.deep.equal(nextProps.searchFilters);
+        expect(fetchMock.callCount).to.equal(0);
+      });
+    });
+
+    describe('when searchFilters prop does not change', () => {
+      const nextProps = { searchFilters };
+
+      it('does not fetch reservations', () => {
+        instance.componentWillUpdate(nextProps);
+        expect(fetchMock.callCount).to.equal(0);
+        expect(throttledFetchMock.callCount).to.equal(0);
+      });
+    });
+  });
+
+  describe('fetchAndChangeUrl', () => {
+    let replaceUrlMock;
+
+    beforeEach(() => {
+      replaceUrlMock = simple.mock(browserHistory, 'replace');
+    });
+
+    afterEach(() => {
+      simple.restore();
+    });
+
+    it('fetches reservations with decamelized filters', () => {
+      const fetchReservations = simple.mock();
+      const instance = getWrapper({ fetchReservations }).instance();
+      const filters = {
+        isFavoriteResource: 'true',
+        eventSubject: 'Meeting',
+      };
+      instance.fetchAndChangeUrl(filters);
+
+      expect(fetchReservations.callCount).to.equal(1);
+      expect(fetchReservations.lastCall.arg).to.deep.equal({
+        is_favorite_resource: 'true',
+        event_subject: 'Meeting',
+      });
+    });
+
+    it('replaces url with correct filters', () => {
+      const fetchReservations = simple.mock();
+      const instance = getWrapper({ fetchReservations }).instance();
+      const filters = {
+        isFavoriteResource: 'true',
+        eventSubject: 'Meeting',
+      };
+      instance.fetchAndChangeUrl(filters);
+
+      const expectedFilters = decamelizeKeys(filters);
+      const expectedPath = `/reservations?${queryString.stringify(expectedFilters)}`;
+      expect(replaceUrlMock.callCount).to.equal(1);
+      expect(replaceUrlMock.lastCall.arg).to.equal(expectedPath);
+    });
+  });
+
+  describe('parseUrlFilters', () => {
+    it('parses filters correctly', () => {
+      const query = {
+        start: '2016-01-01',
+        is_favorite_resource: 'true',
+      };
+      const actual = parseUrlFilters(query);
+      const expected = camelizeKeys(query);
+      expect(actual).to.deep.equal(expected);
+    });
+  });
+});

--- a/app/pages/reservationSearch/day-reservations/DayReservations.js
+++ b/app/pages/reservationSearch/day-reservations/DayReservations.js
@@ -1,0 +1,21 @@
+import React, { PropTypes } from 'react';
+
+import ReservationRow from './reservation-row';
+
+DayReservations.propTypes = {
+  day: PropTypes.object.isRequired,
+  reservations: PropTypes.arrayOf(PropTypes.number.isRequired).isRequired,
+};
+export default function DayReservations({ day, reservations }) {
+  return (
+    <div className="day-reservations">
+      <div className="day">{day.format('dd D.M.YYYY')}</div>
+      <div className="reservations">
+        {reservations.map(id =>
+          <ReservationRow id={id} key={id} />
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/app/pages/reservationSearch/day-reservations/DayReservations.spec.js
+++ b/app/pages/reservationSearch/day-reservations/DayReservations.spec.js
@@ -1,0 +1,34 @@
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import moment from 'moment';
+import React from 'react';
+
+import ReservationRow from './reservation-row';
+import DayReservations from './DayReservations';
+
+function getWrapper(props) {
+  const defaults = {
+    day: moment('2016-01-03'),
+    reservations: [1, 2],
+  };
+  return shallow(<DayReservations {...defaults} {...props} />);
+}
+
+describe('pages/reservationSearch/day-reservations/DayReservations', () => {
+  it('renders a div.day-reservations', () => {
+    const wrapper = getWrapper();
+    expect(wrapper.is('div.day-reservations')).to.be.true;
+  });
+
+  it('renders correctly formatted day', () => {
+    const day = getWrapper().find('.day');
+    expect(day.text()).to.equal('su 3.1.2016');
+  });
+
+  it('renders ReservationRows with correct ids', () => {
+    const rows = getWrapper().find(ReservationRow);
+    expect(rows).to.have.length(2);
+    expect(rows.at(0).prop('id')).to.equal(1);
+    expect(rows.at(1).prop('id')).to.equal(2);
+  });
+});

--- a/app/pages/reservationSearch/day-reservations/day-reservations.less
+++ b/app/pages/reservationSearch/day-reservations/day-reservations.less
@@ -1,0 +1,27 @@
+@import './reservation-row/reservation-row';
+
+.day-reservations {
+  &:not(:first-child) {
+    margin-top: 7px;
+  }
+
+  .day {
+    padding: @padding-base-vertical @padding-base-horizontal;
+    margin-bottom: 2px;
+    background-color: @brand-primary;
+    color: #fff;
+
+    @media (min-width: @screen-md-min) {
+      margin-right: 7px;
+      flex-basis: 17%;
+    }
+  }
+
+  .reservations {
+    flex-grow: 1;
+  }
+
+  @media (min-width: @screen-md-min) {
+    display: flex;
+  }
+}

--- a/app/pages/reservationSearch/day-reservations/index.js
+++ b/app/pages/reservationSearch/day-reservations/index.js
@@ -1,0 +1,1 @@
+export { default } from './DayReservations';

--- a/app/pages/reservationSearch/day-reservations/reservation-row/ReservationRow.js
+++ b/app/pages/reservationSearch/day-reservations/reservation-row/ReservationRow.js
@@ -1,0 +1,30 @@
+import React, { PropTypes } from 'react';
+
+ReservationRow.propTypes = {
+  hostName: PropTypes.string.isRequired,
+  place: PropTypes.string.isRequired,
+  eventSubject: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired,
+  timeRange: PropTypes.string.isRequired,
+};
+export default function ReservationRow({
+  place,
+  eventSubject,
+  hostName,
+  onClick,
+  timeRange,
+}) {
+  return (
+    <a className="reservation-row" onClick={onClick} tabIndex="0">
+      <div className="left">
+        <div className="time-range">{timeRange}</div>
+        <div className="host-name">{hostName}</div>
+      </div>
+      <div className="right">
+        <div className="place">{place}</div>
+        <div className="event-subject">{eventSubject}</div>
+      </div>
+    </a>
+  );
+}
+

--- a/app/pages/reservationSearch/day-reservations/reservation-row/ReservationRow.spec.js
+++ b/app/pages/reservationSearch/day-reservations/reservation-row/ReservationRow.spec.js
@@ -1,0 +1,45 @@
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import ReservationRow from './ReservationRow';
+
+describe('pages/reservationSearch/reservation-row/ReservationRow', () => {
+  const defaults = {
+    place: 'Room 1',
+    eventSubject: 'Meeting',
+    hostName: 'Michael Jackson',
+    onClick: () => null,
+    timeRange: '18:00 - 19:30',
+  };
+
+  function getWrapper(props) {
+    return shallow(<ReservationRow {...defaults} {...props} />);
+  }
+
+  it('renders a.reservation-row with onClick', () => {
+    const wrapper = getWrapper();
+    expect(wrapper.is('a.reservation-row')).to.be.true;
+    expect(wrapper.prop('onClick')).to.equal(defaults.onClick);
+  });
+
+  it('renders time range', () => {
+    const timeRange = getWrapper().find('.time-range');
+    expect(timeRange.text()).to.equal(defaults.timeRange);
+  });
+
+  it('renders host name', () => {
+    const hostName = getWrapper().find('.host-name');
+    expect(hostName.text()).to.equal(defaults.hostName);
+  });
+
+  it('renders place', () => {
+    const place = getWrapper().find('.place');
+    expect(place.text()).to.equal(defaults.place);
+  });
+
+  it('renders event subject', () => {
+    const eventSubject = getWrapper().find('.event-subject');
+    expect(eventSubject.text()).to.equal(defaults.eventSubject);
+  });
+});

--- a/app/pages/reservationSearch/day-reservations/reservation-row/ReservationRowContainer.js
+++ b/app/pages/reservationSearch/day-reservations/reservation-row/ReservationRowContainer.js
@@ -1,0 +1,32 @@
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+import uiActions from 'actions/uiActions';
+import selector from './reservationRowSelector';
+import ReservationRow from './ReservationRow';
+
+UnconnectedReservationRowContainer.propTypes = {
+  eventSubject: PropTypes.string.isRequired,
+  hostName: PropTypes.string.isRequired,
+  id: PropTypes.number.isRequired,
+  onClick: PropTypes.func.isRequired,
+  place: PropTypes.string.isRequired,
+  timeRange: PropTypes.string.isRequired,
+};
+export function UnconnectedReservationRowContainer(props) {
+  return (
+    <ReservationRow
+      eventSubject={props.eventSubject}
+      hostName={props.hostName}
+      onClick={() => props.onClick(props.id)}
+      place={props.place}
+      timeRange={props.timeRange}
+    />
+  );
+}
+
+const actions = {
+  onClick: uiActions.showReservationInfoModal,
+};
+
+export default connect(selector, actions)(UnconnectedReservationRowContainer);

--- a/app/pages/reservationSearch/day-reservations/reservation-row/ReservationRowContainer.spec.js
+++ b/app/pages/reservationSearch/day-reservations/reservation-row/ReservationRowContainer.spec.js
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import {
+  UnconnectedReservationRowContainer as ReservationRowContainer,
+} from './ReservationRowContainer';
+import ReservationRow from './ReservationRow';
+
+describe('pages/reservationSearch/day-reservations/reservation-row/ReservationRowContainer', () => {
+  const defaults = {
+    place: 'Room 1',
+    eventSubject: 'Meeting',
+    hostName: 'Michael Jackson',
+    id: 123,
+    onClick: () => null,
+    timeRange: '18:00 - 19:30',
+  };
+
+  function getWrapper(props) {
+    return shallow(<ReservationRowContainer {...defaults} {...props} />);
+  }
+
+  it('renders ReservationRow with correct props', () => {
+    const row = getWrapper();
+    expect(row.is(ReservationRow)).to.be.true;
+    expect(row.prop('eventSubject')).to.equal(defaults.eventSubject);
+    expect(row.prop('hostName')).to.equal(defaults.hostName);
+    expect(row.prop('onClick')).to.be.a('function');
+    expect(row.prop('place')).to.equal(defaults.place);
+    expect(row.prop('timeRange')).to.equal(defaults.timeRange);
+  });
+});

--- a/app/pages/reservationSearch/day-reservations/reservation-row/index.js
+++ b/app/pages/reservationSearch/day-reservations/reservation-row/index.js
@@ -1,0 +1,1 @@
+export { default } from './ReservationRowContainer';

--- a/app/pages/reservationSearch/day-reservations/reservation-row/reservation-row.less
+++ b/app/pages/reservationSearch/day-reservations/reservation-row/reservation-row.less
@@ -1,0 +1,41 @@
+.reservation-row {
+  display: flex;
+  margin-bottom: 2px;
+
+  &:focus {
+    outline: 0;
+    text-decoration: none;
+  }
+  
+  &:hover {
+    cursor: pointer;
+    text-decoration: none;
+  }
+
+  .left, .right {
+    display: inline-block;
+    padding: @padding-base-vertical @padding-base-horizontal;
+  }
+
+  .left {
+    background-color: @brand-success;
+    color: #fff;
+    flex-basis: 30%;
+  }
+
+  .right {
+    background-color: @background-gray;
+    color: @text-color;
+    flex-basis: 70%;
+  }
+
+  .time-range,
+  .place {
+    font-weight: @bold;
+  }
+
+  .host-name,
+  .event-subject {
+    font-weight: @regular;
+  }
+}

--- a/app/pages/reservationSearch/day-reservations/reservation-row/reservationRowSelector.js
+++ b/app/pages/reservationSearch/day-reservations/reservation-row/reservationRowSelector.js
@@ -1,0 +1,58 @@
+import moment from 'moment';
+import { createSelector } from 'reselect';
+
+function reservationsSelector(state) {
+  return state.data.reservations;
+}
+
+function resourcesSelector(state) {
+  return state.data.resources;
+}
+
+function unitsSelector(state) {
+  return state.data.units;
+}
+
+function reservationIdSelector(state, props) {
+  return props.id;
+}
+
+const reservationSelector = createSelector(
+  reservationsSelector,
+  reservationIdSelector,
+  (reservations, reservationId) => reservations[reservationId]
+);
+
+const resourceSelector = createSelector(
+  resourcesSelector,
+  reservationSelector,
+  (resources, reservation) => resources[reservation.resource]
+);
+
+const unitSelector = createSelector(
+  unitsSelector,
+  resourceSelector,
+  (units, resource) => resource && units[resource.unit]
+);
+
+export default createSelector(
+  reservationSelector,
+  resourceSelector,
+  unitSelector,
+  (reservation, resource, unit) => {
+    const begin = moment(reservation.begin).format('HH:mm');
+    const end = moment(reservation.end).format('HH:mm');
+    const resourceName = resource && resource.name.fi;
+    const unitName = unit && unit.name.fi;
+    const place = unitName && resourceName ?
+      `${unitName} / ${resourceName}` :
+      'Tuntematon tila';
+    return {
+      eventSubject: reservation.eventSubject || 'Tuntematon varauksen nimi',
+      hostName: reservation.hostName || 'Tuntematon isäntä',
+      id: reservation.id,
+      place,
+      timeRange: `${begin} - ${end}`,
+    };
+  }
+);

--- a/app/pages/reservationSearch/day-reservations/reservation-row/reservationRowSelector.spec.js
+++ b/app/pages/reservationSearch/day-reservations/reservation-row/reservationRowSelector.spec.js
@@ -1,0 +1,94 @@
+import { expect } from 'chai';
+
+import { getState } from 'utils/testUtils';
+import reservationRowSelector from './reservationRowSelector';
+
+describe('pages/search/reservationRowSelector', () => {
+  const reservations = {
+    36: {
+      id: 36,
+      begin: '2017-01-01T09:00:00',
+      end: '2017-01-01T10:00:00',
+      eventSubject: 'Meeting',
+      hostName: 'Jaska',
+      resource: 'r-1',
+    },
+    37: {
+      id: 37,
+      begin: '2017-01-02T09:00:00',
+      end: '2017-01-02T10:00:00',
+    },
+  };
+  const resources = {
+    'r-1': { id: 'r-1', name: { fi: 'Room 1' }, unit: 'u-1' },
+    'r-2': { id: 'r-2', name: { fi: 'Room 2' }, unit: 'u-2' },
+  };
+  const units = {
+    'u-1': { id: 'u-1', name: { fi: 'Unit 1' } },
+    'u-2': { id: 'u-2', name: { fi: 'Unit 2' } },
+  };
+
+  function getSelected(id) {
+    const state = getState({
+      'data.reservations': reservations,
+      'data.resources': resources,
+      'data.units': units,
+    });
+    const props = { id };
+    return reservationRowSelector(state, props);
+  }
+
+  let selected;
+
+  describe('reservation with full data', () => {
+    before(() => {
+      selected = getSelected(36);
+    });
+
+    it('returns eventSubject', () => {
+      expect(selected.eventSubject).to.equal('Meeting');
+    });
+
+    it('returns hostName', () => {
+      expect(selected.hostName).to.equal('Jaska');
+    });
+
+    it('returns id', () => {
+      expect(selected.id).to.equal(36);
+    });
+
+    it('returns place', () => {
+      expect(selected.place).to.equal('Unit 1 / Room 1');
+    });
+
+    it('returns timeRange', () => {
+      expect(selected.timeRange).to.equal('09:00 - 10:00');
+    });
+  });
+
+  describe('reservation with partial data', () => {
+    before(() => {
+      selected = getSelected(37);
+    });
+
+    it('returns eventSubject', () => {
+      expect(selected.eventSubject).to.equal('Tuntematon varauksen nimi');
+    });
+
+    it('returns hostName', () => {
+      expect(selected.hostName).to.equal('Tuntematon isäntä');
+    });
+
+    it('returns id', () => {
+      expect(selected.id).to.equal(37);
+    });
+
+    it('returns place', () => {
+      expect(selected.place).to.equal('Tuntematon tila');
+    });
+
+    it('returns timeRange', () => {
+      expect(selected.timeRange).to.equal('09:00 - 10:00');
+    });
+  });
+});

--- a/app/pages/reservationSearch/index.js
+++ b/app/pages/reservationSearch/index.js
@@ -1,0 +1,1 @@
+export { default } from './ReservationSearchPageContainer';

--- a/app/pages/reservationSearch/reservation-search-controls/ReservationSearchControls.js
+++ b/app/pages/reservationSearch/reservation-search-controls/ReservationSearchControls.js
@@ -144,6 +144,7 @@ class ReservationSearchControls extends Component {
               </FormGroup>
             </Col>
           </Row>
+          <hr className="separator" />
           <Row>
             <Col md={4}>
               <FormGroup controlId="unit-control-group">

--- a/app/pages/reservationSearch/reservation-search-controls/ReservationSearchControls.js
+++ b/app/pages/reservationSearch/reservation-search-controls/ReservationSearchControls.js
@@ -1,0 +1,168 @@
+import sortBy from 'lodash/sortBy';
+import React, { Component, PropTypes } from 'react';
+import Checkbox from 'react-bootstrap/lib/Checkbox';
+import ControlLabel from 'react-bootstrap/lib/ControlLabel';
+import FormControl from 'react-bootstrap/lib/FormControl';
+import FormGroup from 'react-bootstrap/lib/FormGroup';
+import Row from 'react-bootstrap/lib/Row';
+import Col from 'react-bootstrap/lib/Col';
+
+function getUnitOption(id, label) {
+  return <option key={id} value={id}>{label}</option>;
+}
+
+function renderUnitOptions(units) {
+  const defaultOption = getUnitOption('', 'Kaikki kiinteistöt');
+  const optionData = Object.keys(units).map((id) => {
+    const unit = units[id];
+    const label = `${unit.name.fi} - ${unit.streetAddress.fi}`;
+    return { id, label };
+  });
+  const sortedOptionData = sortBy(optionData, 'label');
+  const options = sortedOptionData.map(unit => getUnitOption(unit.id, unit.label));
+  return [defaultOption].concat(options);
+}
+
+function preventDefault(event) {
+  event.preventDefault();
+}
+
+class ReservationSearchControls extends Component {
+  static propTypes = {
+    onChange: PropTypes.func.isRequired,
+    values: PropTypes.shape({
+      end: PropTypes.string.isRequired,
+      eventSubject: PropTypes.string.isRequired,
+      hasCatering: PropTypes.string.isRequired,
+      hasEquipment: PropTypes.string.isRequired,
+      hostName: PropTypes.string.isRequired,
+      isFavoriteResource: PropTypes.string.isRequired,
+      isOwn: PropTypes.string.isRequired,
+      reserverName: PropTypes.string.isRequired,
+      resourceName: PropTypes.string.isRequired,
+      start: PropTypes.string.isRequired,
+      unit: PropTypes.string.isRequired,
+    }).isRequired,
+    units: PropTypes.object.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  handleChange(updatedFilter) {
+    this.props.onChange(updatedFilter);
+  }
+
+  render() {
+    return (
+      <div className="search-controls">
+        <form onSubmit={preventDefault}>
+          <Row>
+            <Col md={4}>
+              <FormGroup controlId="event-subject-control-group">
+                <ControlLabel>Hae varauksen nimellä</ControlLabel>
+                <FormControl
+                  onChange={event => this.handleChange({ eventSubject: event.target.value })}
+                  type="text"
+                  value={this.props.values.eventSubject}
+                />
+              </FormGroup>
+            </Col>
+            <Col md={4}>
+              <FormGroup controlId="host-name-control-group">
+                <ControlLabel>Varauksen isäntä</ControlLabel>
+                <FormControl
+                  onChange={event => this.handleChange({ hostName: event.target.value })}
+                  type="text"
+                  value={this.props.values.hostName}
+                />
+              </FormGroup>
+            </Col>
+            <Col md={4}>
+              <Checkbox
+                className="is-own-checkbox"
+                onChange={event =>
+                  this.handleChange({ isOwn: event.target.checked ? 'true' : '' })
+                }
+                checked={this.props.values.isOwn === 'true'}
+              >
+                Näytä vain omat varaukset
+              </Checkbox>
+              <Checkbox
+                className="has-catering-checkbox"
+                disabled
+                onChange={event =>
+                  this.handleChange({ hasCatering: event.target.checked ? 'true' : '' })
+                }
+                checked={this.props.values.hasCatering === 'true'}
+              >
+                Sisältää tarjoilutilauksen
+              </Checkbox>
+              <Checkbox
+                className="has-equipment-checkbox"
+                onChange={event =>
+                  this.handleChange({ hasEquipment: event.target.checked ? 'true' : '' })
+                }
+                checked={this.props.values.hasEquipment === 'true'}
+              >
+                Sisältää lisävarusteita
+              </Checkbox>
+            </Col>
+          </Row>
+          <Row>
+            <Col md={4}>
+              <FormGroup controlId="reserver-name-control-group">
+                <ControlLabel>Varaaja</ControlLabel>
+                <FormControl
+                  onChange={event => this.handleChange({ reserverName: event.target.value })}
+                  type="text"
+                  value={this.props.values.reserverName}
+                />
+              </FormGroup>
+            </Col>
+          </Row>
+          <Row>
+            <Col md={4}>
+              <FormGroup controlId="unit-control-group">
+                <ControlLabel>Kiinteistö</ControlLabel>
+                <FormControl
+                  componentClass="select"
+                  onChange={event => this.handleChange({ unit: event.target.value })}
+                  type="select"
+                  value={this.props.values.unit}
+                >
+                  {renderUnitOptions(this.props.units)}
+                </FormControl>
+              </FormGroup>
+            </Col>
+            <Col md={4}>
+              <FormGroup controlId="resource-name-control-group">
+                <ControlLabel>Tilan nimi</ControlLabel>
+                <FormControl
+                  onChange={event => this.handleChange({ resourceName: event.target.value })}
+                  type="text"
+                  value={this.props.values.resourceName}
+                />
+              </FormGroup>
+            </Col>
+            <Col md={4}>
+              <Checkbox
+                className="is-favorite-resource-checkbox"
+                onChange={event =>
+                  this.handleChange({ isFavoriteResource: event.target.checked ? 'true' : '' })
+                }
+                checked={this.props.values.isFavoriteResource === 'true'}
+              >
+                Näytä vain omat suosikkitilat
+              </Checkbox>
+            </Col>
+          </Row>
+        </form>
+      </div>
+    );
+  }
+}
+
+export default ReservationSearchControls;

--- a/app/pages/reservationSearch/reservation-search-controls/ReservationSearchControls.js
+++ b/app/pages/reservationSearch/reservation-search-controls/ReservationSearchControls.js
@@ -1,3 +1,4 @@
+import FontAwesome from 'react-fontawesome';
 import sortBy from 'lodash/sortBy';
 import React, { Component, PropTypes } from 'react';
 import Checkbox from 'react-bootstrap/lib/Checkbox';
@@ -6,6 +7,8 @@ import FormControl from 'react-bootstrap/lib/FormControl';
 import FormGroup from 'react-bootstrap/lib/FormGroup';
 import Row from 'react-bootstrap/lib/Row';
 import Col from 'react-bootstrap/lib/Col';
+
+import DatePicker from 'shared/date-picker';
 
 function getUnitOption(id, label) {
   return <option key={id} value={id}>{label}</option>;
@@ -57,7 +60,7 @@ class ReservationSearchControls extends Component {
 
   render() {
     return (
-      <div className="search-controls">
+      <div className="reservation-search-controls">
         <form onSubmit={preventDefault}>
           <Row>
             <Col md={4}>
@@ -112,6 +115,24 @@ class ReservationSearchControls extends Component {
             </Col>
           </Row>
           <Row>
+            <Col md={4}>
+              <FormGroup controlId="dates-control-group">
+                <ControlLabel>Varaukset aikavälillä</ControlLabel>
+                <div className="date-pickers-container">
+                  <DatePicker
+                    onChange={start => this.handleChange({ start })}
+                    value={this.props.values.start}
+                  />
+                  <div className="delimiter">
+                    <FontAwesome name="caret-right" />
+                  </div>
+                  <DatePicker
+                    onChange={end => this.handleChange({ end })}
+                    value={this.props.values.end}
+                  />
+                </div>
+              </FormGroup>
+            </Col>
             <Col md={4}>
               <FormGroup controlId="reserver-name-control-group">
                 <ControlLabel>Varaaja</ControlLabel>

--- a/app/pages/reservationSearch/reservation-search-controls/ReservationSearchControls.spec.js
+++ b/app/pages/reservationSearch/reservation-search-controls/ReservationSearchControls.spec.js
@@ -1,0 +1,268 @@
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import React from 'react';
+import Checkbox from 'react-bootstrap/lib/Checkbox';
+import ControlLabel from 'react-bootstrap/lib/ControlLabel';
+import FormControl from 'react-bootstrap/lib/FormControl';
+import simple from 'simple-mock';
+
+import DatePicker from 'shared/date-picker';
+import ReservationSearchControls from './ReservationSearchControls';
+
+describe('pages/reservationSearch/reservation-search-controls/ReservationSearchControls', () => {
+  const defaultValues = {
+    end: '2016-12-12',
+    eventSubject: '',
+    hasCatering: '',
+    hasEquipment: '',
+    hostName: '',
+    isFavoriteResource: '',
+    isOwn: '',
+    reserverName: '',
+    resourceName: '',
+    start: '2016-11-12',
+    unit: '',
+  };
+  const units = {
+    abd: {
+      name: { fi: 'Some unit' },
+      streetAddress: { fi: 'Aleksanterinkatu 22' },
+    },
+    abc: {
+      name: { fi: 'Bockin talo' },
+      streetAddress: { fi: 'Aleksanterinkatu 20' },
+    },
+  };
+
+  function getWrapper(props) {
+    const defaults = {
+      onChange: () => null,
+      values: defaultValues,
+      units,
+    };
+    return shallow(<ReservationSearchControls {...defaults} {...props} />);
+  }
+
+  describe('render', () => {
+    it('renders form', () => {
+      const wrapper = getWrapper();
+      const form = wrapper.find('form');
+      expect(form).to.have.length(1);
+    });
+
+    describe('eventSubject control', () => {
+      function getEventSubjectControlWrapper(values) {
+        const wrapper = getWrapper({
+          values: Object.assign({}, defaultValues, values),
+        });
+        return wrapper.find('[controlId="event-subject-control-group"]');
+      }
+
+      it('has correct label', () => {
+        const controlLabel = getEventSubjectControlWrapper().find(ControlLabel);
+        expect(controlLabel.prop('children')).to.equal('Hae varauksen nimellä');
+      });
+
+      it('has correct initial value', () => {
+        const eventSubject = 'Meeting';
+        const control = getEventSubjectControlWrapper({ eventSubject }).find(FormControl);
+        expect(control.prop('value')).to.equal(eventSubject);
+      });
+    });
+
+    describe('hostName control', () => {
+      function getHostNameControlWrapper(values) {
+        const wrapper = getWrapper({
+          values: Object.assign({}, defaultValues, values),
+        });
+        return wrapper.find('[controlId="host-name-control-group"]');
+      }
+
+      it('has correct label', () => {
+        const controlLabel = getHostNameControlWrapper().find(ControlLabel);
+        expect(controlLabel.prop('children')).to.equal('Varauksen isäntä');
+      });
+
+      it('has correct initial value', () => {
+        const hostName = 'Pena';
+        const control = getHostNameControlWrapper({ hostName }).find(FormControl);
+        expect(control.prop('value')).to.equal(hostName);
+      });
+    });
+
+    describe('isOwn control', () => {
+      function getCheckboxWrapper(values) {
+        const wrapper = getWrapper({
+          values: Object.assign({}, defaultValues, values),
+        });
+        return wrapper.find('.is-own-checkbox');
+      }
+
+      it('has correct label', () => {
+        const label = getCheckboxWrapper().prop('children');
+        expect(label).to.equal('Näytä vain omat varaukset');
+      });
+
+      it('renders Checkbox with correct value', () => {
+        const checkbox = getCheckboxWrapper(
+          { isOwn: 'true' }
+        ).find(Checkbox);
+        expect(checkbox).to.have.length(1);
+        expect(checkbox.prop('checked')).to.equal(true);
+      });
+    });
+
+    describe('hasCatering control', () => {
+      function getCheckboxWrapper(values) {
+        const wrapper = getWrapper({
+          values: Object.assign({}, defaultValues, values),
+        });
+        return wrapper.find('.has-catering-checkbox');
+      }
+
+      it('has correct label', () => {
+        const label = getCheckboxWrapper().prop('children');
+        expect(label).to.equal('Sisältää tarjoilutilauksen');
+      });
+
+      it('renders Checkbox with correct value', () => {
+        const checkbox = getCheckboxWrapper(
+          { hasCatering: 'true' }
+        ).find(Checkbox);
+        expect(checkbox).to.have.length(1);
+        expect(checkbox.prop('checked')).to.equal(true);
+      });
+    });
+
+    describe('hasEquipment control', () => {
+      function getCheckboxWrapper(values) {
+        const wrapper = getWrapper({
+          values: Object.assign({}, defaultValues, values),
+        });
+        return wrapper.find('.has-equipment-checkbox');
+      }
+
+      it('has correct label', () => {
+        const label = getCheckboxWrapper().prop('children');
+        expect(label).to.equal('Sisältää lisävarusteita');
+      });
+
+      it('renders Checkbox with correct value', () => {
+        const checkbox = getCheckboxWrapper(
+          { hasEquipment: 'true' }
+        ).find(Checkbox);
+        expect(checkbox).to.have.length(1);
+        expect(checkbox.prop('checked')).to.equal(true);
+      });
+    });
+
+    describe('reserverName control', () => {
+      function getReserverNameControlWrapper(values) {
+        const wrapper = getWrapper({
+          values: Object.assign({}, defaultValues, values),
+        });
+        return wrapper.find('[controlId="reserver-name-control-group"]');
+      }
+
+      it('has correct label', () => {
+        const controlLabel = getReserverNameControlWrapper().find(ControlLabel);
+        expect(controlLabel.prop('children')).to.equal('Varaaja');
+      });
+
+      it('has correct initial value', () => {
+        const reserverName = 'Pena';
+        const control = getReserverNameControlWrapper({ reserverName }).find(FormControl);
+        expect(control.prop('value')).to.equal(reserverName);
+      });
+    });
+
+    describe('unit control', () => {
+      function getUnitControlWrapper(values) {
+        const wrapper = getWrapper({
+          values: Object.assign({}, defaultValues, values),
+        });
+        return wrapper.find('[controlId="unit-control-group"]');
+      }
+
+      it('has correct label', () => {
+        const controlLabel = getUnitControlWrapper().find(ControlLabel);
+        expect(controlLabel.prop('children')).to.equal('Kiinteistö');
+      });
+
+      it('renders select field with correct value', () => {
+        const unit = 'abc';
+        const field = getUnitControlWrapper({ unit }).find(FormControl);
+        expect(field).to.have.length(1);
+        expect(field.prop('value')).to.equal(unit);
+      });
+
+      it('renders correct options sorted by label', () => {
+        const field = getUnitControlWrapper().find(FormControl);
+        const option = field.find('option');
+        expect(option).to.have.length(3);
+
+        expect(option.at(0).prop('value')).to.equal('');
+        expect(option.at(0).text()).to.equal('Kaikki kiinteistöt');
+
+        expect(option.at(1).prop('value')).to.equal('abc');
+        expect(option.at(1).text()).to.equal('Bockin talo - Aleksanterinkatu 20');
+
+        expect(option.at(2).prop('value')).to.equal('abd');
+        expect(option.at(2).text()).to.equal('Some unit - Aleksanterinkatu 22');
+      });
+    });
+
+    describe('resourceName control', () => {
+      function getResourceNameControlWrapper(values) {
+        const wrapper = getWrapper({
+          values: Object.assign({}, defaultValues, values),
+        });
+        return wrapper.find('[controlId="resource-name-control-group"]');
+      }
+
+      it('has correct label', () => {
+        const controlLabel = getResourceNameControlWrapper().find(ControlLabel);
+        expect(controlLabel.prop('children')).to.equal('Tilan nimi');
+      });
+
+      it('has correct initial value', () => {
+        const resourceName = 'Pena';
+        const control = getResourceNameControlWrapper({ resourceName }).find(FormControl);
+        expect(control.prop('value')).to.equal(resourceName);
+      });
+    });
+
+    describe('isFavoriteResource control', () => {
+      function getCheckboxWrapper(values) {
+        const wrapper = getWrapper({
+          values: Object.assign({}, defaultValues, values),
+        });
+        return wrapper.find('.is-favorite-resource-checkbox');
+      }
+
+      it('has correct label', () => {
+        const label = getCheckboxWrapper().prop('children');
+        expect(label).to.equal('Näytä vain omat suosikkitilat');
+      });
+
+      it('renders Checkbox with correct value', () => {
+        const checkbox = getCheckboxWrapper(
+          { isFavoriteResource: 'true' }
+        ).find(Checkbox);
+        expect(checkbox).to.have.length(1);
+        expect(checkbox.prop('checked')).to.equal(true);
+      });
+    });
+  });
+
+  describe('handleChange', () => {
+    it('calls onChange with updated filter', () => {
+      const onChange = simple.mock();
+      const instance = getWrapper({ onChange }).instance();
+      const filters = { search: 'search text' };
+      instance.handleChange(filters);
+      expect(onChange.callCount).to.equal(1);
+      expect(onChange.lastCall.arg).to.deep.equal(filters);
+    });
+  });
+});

--- a/app/pages/reservationSearch/reservation-search-controls/ReservationSearchControls.spec.js
+++ b/app/pages/reservationSearch/reservation-search-controls/ReservationSearchControls.spec.js
@@ -156,6 +156,32 @@ describe('pages/reservationSearch/reservation-search-controls/ReservationSearchC
       });
     });
 
+    describe('date controls', () => {
+      function getDatesControlWrapper(values) {
+        const wrapper = getWrapper({
+          values: Object.assign({}, defaultValues, values),
+        });
+        return wrapper.find('[controlId="dates-control-group"]');
+      }
+
+      it('has correct label', () => {
+        const controlLabel = getDatesControlWrapper().find(ControlLabel);
+        expect(controlLabel.prop('children')).to.equal('Varaukset aikavälillä');
+      });
+
+      it('start has correct initial value', () => {
+        const start = '2016-04-05';
+        const startDatePicker = getDatesControlWrapper({ start }).find(DatePicker).at(0);
+        expect(startDatePicker.prop('value')).to.equal(start);
+      });
+
+      it('end has correct initial value', () => {
+        const end = '2016-04-15';
+        const endDatePicker = getDatesControlWrapper({ end }).find(DatePicker).at(1);
+        expect(endDatePicker.prop('value')).to.equal(end);
+      });
+    });
+
     describe('reserverName control', () => {
       function getReserverNameControlWrapper(values) {
         const wrapper = getWrapper({

--- a/app/pages/reservationSearch/reservation-search-controls/index.js
+++ b/app/pages/reservationSearch/reservation-search-controls/index.js
@@ -1,0 +1,1 @@
+export { default } from './ReservationSearchControls';

--- a/app/pages/reservationSearch/reservation-search-controls/reservation-search-controls.less
+++ b/app/pages/reservationSearch/reservation-search-controls/reservation-search-controls.less
@@ -1,4 +1,8 @@
 .reservation-search-controls {
+  background-color: @gray-lighter;
+  padding: @padding-base-vertical @padding-base-horizontal;
+  margin-bottom: 30px;
+
   .date-pickers-container {
     display: flex;
     justify-content: flex-start;
@@ -14,9 +18,22 @@
   .date-picker {
     border: 2px solid @input-border;
     .input-size(@input-height-base; @padding-base-vertical; @padding-base-horizontal; @font-size-base; @line-height-base; @input-border-radius);
+    background-color: #fff;
 
     input {
       padding: 0;
+    }
+  }
+
+  .separator {
+    margin: 10px 0 15px;
+    border-top: 2px solid @gray-light;
+  }
+
+  @media (min-width: @screen-md-min) {
+    .is-favorite-resource-checkbox {
+      position: relative;
+      top: 28px;
     }
   }
 }

--- a/app/pages/reservationSearch/reservation-search-controls/reservation-search-controls.less
+++ b/app/pages/reservationSearch/reservation-search-controls/reservation-search-controls.less
@@ -1,0 +1,22 @@
+.reservation-search-controls {
+  .date-pickers-container {
+    display: flex;
+    justify-content: flex-start;
+
+    .delimiter {
+      display: flex;
+      align-items: center;
+      padding: 0 8px;
+      font-size: 32px;
+    }
+  }
+
+  .date-picker {
+    border: 2px solid @input-border;
+    .input-size(@input-height-base; @padding-base-vertical; @padding-base-horizontal; @font-size-base; @line-height-base; @input-border-radius);
+
+    input {
+      padding: 0;
+    }
+  }
+}

--- a/app/pages/reservationSearch/reservation-search-page.less
+++ b/app/pages/reservationSearch/reservation-search-page.less
@@ -1,0 +1,5 @@
+@import './day-reservations/day-reservations';
+
+.reservation-search-page {
+  width: 100%;
+}

--- a/app/pages/reservationSearch/reservation-search-page.less
+++ b/app/pages/reservationSearch/reservation-search-page.less
@@ -3,4 +3,8 @@
 
 .reservation-search-page {
   width: 100%;
+
+  .search-results-container {
+    position: relative;
+  }
 }

--- a/app/pages/reservationSearch/reservation-search-page.less
+++ b/app/pages/reservationSearch/reservation-search-page.less
@@ -1,4 +1,5 @@
 @import './day-reservations/day-reservations';
+@import './reservation-search-controls/reservation-search-controls';
 
 .reservation-search-page {
   width: 100%;

--- a/app/pages/reservationSearch/reservationSearchPageSelector.js
+++ b/app/pages/reservationSearch/reservationSearchPageSelector.js
@@ -1,0 +1,57 @@
+import groupBy from 'lodash/groupBy';
+import sortBy from 'lodash/sortBy';
+import moment from 'moment';
+import { createSelector, createStructuredSelector } from 'reselect';
+
+import { reservationsGetIsActiveSelector } from 'api/selectors';
+
+function searchFiltersSelector(state) {
+  return state.reservationSearchPage.searchFilters;
+}
+
+function unitsSelector(state) {
+  return state.data.units;
+}
+
+const reservationsSelector = createSelector(
+  state => state.data.reservations,
+  state => state.reservationSearchPage.searchResults,
+  (reservations, reservationIds) => reservationIds.map(id => reservations[id])
+);
+
+const resultCountSelector = createSelector(
+  state => state.reservationSearchPage.searchResults,
+  reservationIds => reservationIds.length
+);
+
+const reservationGroupsSelector = createSelector(
+  reservationsSelector,
+  (reservations) => {
+    if (!reservations.length) {
+      return [];
+    }
+    const groupedReservations = groupBy(
+      reservations,
+      reservation => moment(reservation.begin).format('YYYY-MM-DD'),
+    );
+    const groups = Object.keys(groupedReservations).map((day) => {
+      const reservationIds = (
+        sortBy(groupedReservations[day], 'begin', 'end', 'id')
+        .map(reservation => reservation.id)
+      );
+      return {
+        day: moment(day),
+        reservations: reservationIds,
+      };
+    });
+    return sortBy(groups, 'day');
+  }
+);
+
+export default createStructuredSelector({
+  isFetching: reservationsGetIsActiveSelector,
+  reservationGroups: reservationGroupsSelector,
+  resultsCount: resultCountSelector,
+  searchFilters: searchFiltersSelector,
+  units: unitsSelector,
+});

--- a/app/pages/reservationSearch/reservationSearchPageSelector.spec.js
+++ b/app/pages/reservationSearch/reservationSearchPageSelector.spec.js
@@ -1,0 +1,66 @@
+import { expect } from 'chai';
+import moment from 'moment';
+
+import { getState } from 'utils/testUtils';
+import reservationSearchPageSelector from './reservationSearchPageSelector';
+
+describe('pages/search/reservationSearchPageSelector', () => {
+  const reservations = {
+    'rsv-1': { id: 'rsv-1', begin: '2016-11-12' },
+    'rsv-2': { id: 'rsv-2', begin: '2016-11-14' },
+    'rsv-3': { id: 'rsv-3', begin: '2016-11-14' },
+    'rsv-4': { id: 'rsv-4', begin: '2016-11-12' },
+  };
+  const units = {
+    'u-1': { id: 'u-1', name: { fi: 'Unit 1' } },
+    'u-2': { id: 'u-2', name: { fi: 'Unit 2' } },
+  };
+  const searchFilters = {
+    end: '2016-12-12',
+    eventSubject: '',
+    hasCatering: '',
+    hasEquipment: '',
+    hostName: '',
+    isFavoriteResource: '',
+    isOwn: '',
+    reserverName: '',
+    resourceName: '',
+    start: '2016-11-12',
+    unit: '',
+  };
+  const searchResults = ['rsv-1', 'rsv-2', 'rsv-3'];
+
+  function getSelected() {
+    const state = getState({
+      'data.reservations': reservations,
+      'data.units': units,
+      'reservationSearchPage.searchFilters': searchFilters,
+      'reservationSearchPage.searchResults': searchResults,
+    });
+    return reservationSearchPageSelector(state);
+  }
+
+  it('returns isFetching', () => {
+    expect(getSelected().isFetching).to.exist;
+  });
+
+  it('returns reservationGroups corresponding to search results', () => {
+    const expected = [
+      { day: moment('2016-11-12'), reservations: ['rsv-1'] },
+      { day: moment('2016-11-14'), reservations: ['rsv-2', 'rsv-3'] },
+    ];
+    expect(getSelected().reservationGroups).to.deep.equal(expected);
+  });
+
+  it('returns resultsCount from the state', () => {
+    expect(getSelected().resultsCount).to.deep.equal(searchResults.length);
+  });
+
+  it('returns searchFilters from the state', () => {
+    expect(getSelected().searchFilters).to.deep.equal(searchFilters);
+  });
+
+  it('returns units from the state', () => {
+    expect(getSelected().units).to.deep.equal(units);
+  });
+});

--- a/app/pages/search/SearchPageContainer.js
+++ b/app/pages/search/SearchPageContainer.js
@@ -150,7 +150,7 @@ export class UnconnectedSearchPageContainer extends Component {
     const resourceIds = flatten(availabilityGroups.map(group => group.resources));
     return (
       <div className="search-page">
-        <h1>Hae tiloja</h1>
+        <h1>Tilat</h1>
         <SearchControls
           equipment={equipment}
           values={searchFilters}

--- a/app/pages/search/SearchPageContainer.js
+++ b/app/pages/search/SearchPageContainer.js
@@ -1,6 +1,5 @@
-import { camelizeKeys, decamelizeKeys } from 'humps';
+import { decamelizeKeys } from 'humps';
 import flatten from 'lodash/flatten';
-import isEmpty from 'lodash/isEmpty';
 import isEqual from 'lodash/isEqual';
 import debounce from 'lodash/debounce';
 import React, { Component, PropTypes } from 'react';
@@ -13,32 +12,8 @@ import { fetchResources } from 'api/actions';
 import ResourceDailyReportButton from 'shared/resource-daily-report-button';
 import AvailabilityView from 'shared/availability-view';
 import resourceSearchUtils from 'utils/resourceSearchUtils';
-import timeUtils from 'utils/timeUtils';
 import SearchControls from './search-controls';
 import selector from './searchPageSelector';
-
-const DATE_FORMAT = 'YYYY-MM-DD';
-const TIME_FORMAT = 'HH:mm';
-
-function getAvailableFilters(availableBetween) {
-  if (!availableBetween) return {};
-  const parts = availableBetween.split(',');
-  if (parts.length !== 2) return {};
-  const start = timeUtils.parseDateTime(parts[0]);
-  const end = timeUtils.parseDateTime(parts[1]);
-  if (!start || !end) return {};
-  return {
-    availableStartDate: start.format(DATE_FORMAT),
-    availableStartTime: start.format(TIME_FORMAT),
-    availableEndDate: end.format(DATE_FORMAT),
-    availableEndTime: end.format(TIME_FORMAT),
-  };
-}
-
-export function parseUrlFilters(queryParams) {
-  const { availableBetween, ...regular } = camelizeKeys(queryParams);
-  return { ...getAvailableFilters(availableBetween), ...regular };
-}
 
 function didAvailableBetweenChange(updatedFilters) {
   if (!updatedFilters.availableStartDate) return false;
@@ -59,12 +34,7 @@ export class UnconnectedSearchPageContainer extends Component {
   }
 
   componentDidMount() {
-    const urlFilters = parseUrlFilters({ ...this.props.location.query });
-    if (isEmpty(urlFilters)) {
-      this.fetch(this.props.searchFilters);
-    } else {
-      this.props.changeFilters(urlFilters);
-    }
+    this.fetch(this.props.searchFilters);
   }
 
   componentWillUpdate(nextProps) {
@@ -191,7 +161,6 @@ UnconnectedSearchPageContainer.propTypes = {
   equipment: PropTypes.object.isRequired,
   isFetching: PropTypes.bool.isRequired,
   fetchResources: PropTypes.func.isRequired,
-  location: PropTypes.shape({ query: PropTypes.object }).isRequired,
   resultsCount: PropTypes.number.isRequired,
   searchFilters: PropTypes.object.isRequired,
   types: PropTypes.object.isRequired,

--- a/app/pages/search/SearchPageContainer.js
+++ b/app/pages/search/SearchPageContainer.js
@@ -128,23 +128,25 @@ export class UnconnectedSearchPageContainer extends Component {
           units={units}
           types={types}
         />
-        <Loader loaded={!isFetching}>
-          <div className="search-results-count">
-            <span>{searchResultsText} </span>
-            <Link to="/">Tyhjennä haku.</Link>
-          </div>
-          <AvailabilityView
-            date={searchFilters.date}
-            groups={availabilityGroups}
-            onDateChange={this.handleDateChange}
-          />
-          {resourceIds.length !== 0 &&
-            <ResourceDailyReportButton
-              resourceIds={resourceIds}
+        <div className="search-results-container">
+          <Loader loaded={!isFetching}>
+            <div className="search-results-count">
+              <span>{searchResultsText} </span>
+              <Link to="/">Tyhjennä haku.</Link>
+            </div>
+            <AvailabilityView
               date={searchFilters.date}
+              groups={availabilityGroups}
+              onDateChange={this.handleDateChange}
             />
-          }
-        </Loader>
+            {resourceIds.length !== 0 &&
+              <ResourceDailyReportButton
+                resourceIds={resourceIds}
+                date={searchFilters.date}
+              />
+            }
+          </Loader>
+        </div>
       </div>
     );
   }

--- a/app/pages/search/SearchPageContainer.spec.js
+++ b/app/pages/search/SearchPageContainer.spec.js
@@ -74,7 +74,7 @@ describe('pages/search/SearchPageContainer', () => {
       it('renders a header with correct text', () => {
         const header = wrapper.find('h1');
         expect(header.length).to.equal(1);
-        expect(header.text()).to.equal('Hae tiloja');
+        expect(header.text()).to.equal('Tilat');
       });
 
       it('renders SearchControls with correct props', () => {

--- a/app/pages/search/search-controls/search-controls.less
+++ b/app/pages/search/search-controls/search-controls.less
@@ -4,7 +4,7 @@
   .advanced-controls,
   .basic-controls {
     background-color: @gray-lighter;
-    padding: 10px;
+    padding: @padding-base-vertical @padding-base-horizontal;
   }
 
   .available-between-control-group {

--- a/app/pages/search/search-page.less
+++ b/app/pages/search/search-page.less
@@ -1,12 +1,7 @@
 @import './search-controls/search-controls';
 
-.search-results-count {
-  text-align: center;
-  margin-bottom: 20px;
-  padding: 10px;
-  background-color: @background-gray;
-}
-
-.resource-daily-report-button {
-  margin-top: 10px;
+.search-page {
+  .search-results-container {
+    position: relative;
+  }
 }

--- a/app/routes.js
+++ b/app/routes.js
@@ -4,6 +4,7 @@ import { createAction } from 'redux-actions';
 
 import AppContainer from 'pages/AppContainer';
 import SearchPage from 'pages/search';
+import ReservationSearchPage from 'pages/reservationSearch';
 import ResourcePage from 'pages/resource';
 import store from 'state/store';
 
@@ -27,6 +28,7 @@ export default (
     <Route component={AppContainer} path="/">
       <IndexRoute component={SearchPage} {...getDispatchers('SEARCH')} />
       <Route component={ResourcePage} path="/resources/:id" {...getDispatchers('RESOURCE')} />
+      <Route component={ReservationSearchPage} path="/reservations" {...getDispatchers('RESERVATION_SEARCH')} />
     </Route>
   </Route>
 );

--- a/app/shared/navbar/Navbar.js
+++ b/app/shared/navbar/Navbar.js
@@ -5,6 +5,7 @@ import RBNavbar from 'react-bootstrap/lib/Navbar';
 import NavDropdown from 'react-bootstrap/lib/NavDropdown';
 import NavItem from 'react-bootstrap/lib/NavItem';
 import { IndexLink } from 'react-router';
+import { IndexLinkContainer, LinkContainer } from 'react-router-bootstrap';
 
 import Logo from 'shared/logo';
 
@@ -15,10 +16,18 @@ function Navbar(props) {
         <RBNavbar.Brand>
           <IndexLink to="/">
             <Logo />
-            Huonevarausjärjestelmä
+            Huonevaraus
           </IndexLink>
         </RBNavbar.Brand>
       </RBNavbar.Header>
+      <Nav className="links">
+        <IndexLinkContainer to="/">
+          <NavItem>Tilat</NavItem>
+        </IndexLinkContainer>
+        <LinkContainer to="/reservations">
+          <NavItem>Varaukset</NavItem>
+        </LinkContainer>
+      </Nav>
       <Nav navbar pullRight>
         {!props.user &&
           <NavItem href="/login">Kirjaudu sisään</NavItem>

--- a/app/shared/navbar/Navbar.spec.js
+++ b/app/shared/navbar/Navbar.spec.js
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import RBNavbar from 'react-bootstrap/lib/Navbar';
 import NavDropdown from 'react-bootstrap/lib/NavDropdown';
+import NavItem from 'react-bootstrap/lib/NavItem';
 import { IndexLink } from 'react-router';
 
 import Logo from 'shared/logo';
@@ -45,7 +46,34 @@ describe('shared/navbar/Navbar', () => {
     });
 
     it('displays the title of the service', () => {
-      expect(getHomeLinkWrapper().html()).to.contain('Huonevarausjärjestelmä');
+      expect(getHomeLinkWrapper().html()).to.contain('Huonevaraus');
+    });
+  });
+
+  describe('links container', () => {
+    function getPageLinksWrapper(props) {
+      return getWrapper(props).find('.links');
+    }
+
+    it('is rendered', () => {
+      const links = getPageLinksWrapper();
+      expect(links).to.have.length(1);
+    });
+
+    it('contains link to resource search page', () => {
+      const links = getPageLinksWrapper();
+      const link = links.children().at(0);
+      expect(link.prop('to')).to.equal('/');
+      const linkText = link.find(NavItem).children().text();
+      expect(linkText).to.equal('Tilat');
+    });
+
+    it('contains link to reservation search page', () => {
+      const links = getPageLinksWrapper();
+      const link = links.children().at(1);
+      expect(link.prop('to')).to.equal('/reservations');
+      const linkText = link.find(NavItem).children().text();
+      expect(linkText).to.equal('Varaukset');
     });
   });
 

--- a/app/shared/navbar/navbar.less
+++ b/app/shared/navbar/navbar.less
@@ -13,3 +13,11 @@
 .navbar-inverse .navbar-brand:focus {
   color: #fff;
 }
+
+.navbar {
+  .links {
+    a {
+      color: #fff;
+    }
+  }
+}

--- a/app/state/reducers/index.js
+++ b/app/state/reducers/index.js
@@ -8,6 +8,8 @@ import formPlugins from './formPlugins';
 import resourcePage from './resourcePageReducer';
 import reservationCancel from './reservationCancelModalReducer';
 import reservationInfo from './reservationInfoModalReducer';
+import reservationSearchFilters from './reservationSearchFiltersReducer';
+import reservationSearchResults from './reservationSearchResultsReducer';
 import resourceImages from './resourceImagesModalReducer';
 import searchFilters from './searchFiltersReducer';
 import searchResults from './searchResultsReducer';
@@ -22,6 +24,10 @@ export default combineReducers({
     reservationCancel,
     reservationInfo,
     resourceImages,
+  }),
+  reservationSearchPage: combineReducers({
+    searchFilters: reservationSearchFilters,
+    searchResults: reservationSearchResults,
   }),
   resourcePage,
   searchPage: combineReducers({

--- a/app/state/reducers/reservationSearchFiltersReducer.js
+++ b/app/state/reducers/reservationSearchFiltersReducer.js
@@ -1,6 +1,13 @@
-import isEmpty from 'lodash/isEmpty';
+import { camelizeKeys } from 'humps';
+import pick from 'lodash/pick';
 import moment from 'moment';
 import { handleActions } from 'redux-actions';
+
+export function parseUrlFilters(queryParams) {
+  const camelized = camelizeKeys(queryParams);
+  const correctKeys = Object.keys(getInitialState());
+  return pick(camelized, correctKeys);
+}
 
 export function getInitialState() {
   return {
@@ -24,7 +31,10 @@ export default handleActions({
     ...action.payload,
   }),
   ENTER_OR_CHANGE_RESERVATION_SEARCH_PAGE: (state, action) => {
-    if (isEmpty(action.payload.query)) return getInitialState();
-    return state;
+    const urlFilters = parseUrlFilters({ ...action.payload.query });
+    return {
+      ...getInitialState(),
+      ...urlFilters,
+    };
   },
 }, getInitialState());

--- a/app/state/reducers/reservationSearchFiltersReducer.js
+++ b/app/state/reducers/reservationSearchFiltersReducer.js
@@ -1,0 +1,30 @@
+import isEmpty from 'lodash/isEmpty';
+import moment from 'moment';
+import { handleActions } from 'redux-actions';
+
+export function getInitialState() {
+  return {
+    end: moment().add(1, 'months').format('YYYY-MM-DD'),
+    eventSubject: '',
+    hasCatering: '',
+    hasEquipment: '',
+    hostName: '',
+    isFavoriteResource: '',
+    isOwn: '',
+    reserverName: '',
+    resourceName: '',
+    start: moment().format('YYYY-MM-DD'),
+    unit: '',
+  };
+}
+
+export default handleActions({
+  CHANGE_RESERVATION_SEARCH_FILTERS: (state, action) => ({
+    ...state,
+    ...action.payload,
+  }),
+  ENTER_OR_CHANGE_RESERVATION_SEARCH_PAGE: (state, action) => {
+    if (isEmpty(action.payload.query)) return getInitialState();
+    return state;
+  },
+}, getInitialState());

--- a/app/state/reducers/reservationSearchFiltersReducer.spec.js
+++ b/app/state/reducers/reservationSearchFiltersReducer.spec.js
@@ -1,0 +1,123 @@
+import { expect } from 'chai';
+import moment from 'moment';
+import { createAction } from 'redux-actions';
+
+import reservationSearchFiltersReducer, { getInitialState } from './reservationSearchFiltersReducer';
+
+describe('state/reducers/reservationSearchFiltersReducer', () => {
+  describe('initial state', () => {
+    function getInitial() {
+      return reservationSearchFiltersReducer(undefined, { type: 'NOOP' });
+    }
+
+    it('end is the current date plus one month', () => {
+      const expected = moment().add(1, 'months').format('YYYY-MM-DD');
+      expect(getInitial().end).to.equal(expected);
+    });
+
+    it('eventSubject is an empty string', () => {
+      expect(getInitial().eventSubject).to.equal('');
+    });
+
+    it('hasCatering is an empty string', () => {
+      expect(getInitial().hasCatering).to.equal('');
+    });
+
+    it('hasEquipment is an empty string', () => {
+      expect(getInitial().hasEquipment).to.equal('');
+    });
+
+    it('hostName is an empty string', () => {
+      expect(getInitial().hostName).to.equal('');
+    });
+
+    it('isFavoriteResource is an empty string', () => {
+      expect(getInitial().isFavoriteResource).to.equal('');
+    });
+
+    it('isOwn is an empty string', () => {
+      expect(getInitial().isOwn).to.equal('');
+    });
+
+    it('reserverName is an empty string', () => {
+      expect(getInitial().reserverName).to.equal('');
+    });
+
+    it('resourceName is an empty string', () => {
+      expect(getInitial().resourceName).to.equal('');
+    });
+
+    it('start is the current date', () => {
+      const expected = moment().format('YYYY-MM-DD');
+      expect(getInitial().start).to.equal(expected);
+    });
+
+    it('unit is an empty string', () => {
+      expect(getInitial().unit).to.equal('');
+    });
+  });
+
+  describe('handling actions', () => {
+    describe('CHANGE_RESERVATION_SEARCH_FILTERS', () => {
+      const routeChangedAction = createAction('CHANGE_RESERVATION_SEARCH_FILTERS');
+
+      it('sets parameters in payload to filters', () => {
+        const currentState = {};
+        const payload = {
+          start: '2016-12-12',
+          is_favorite: '',
+        };
+        const action = routeChangedAction(payload);
+        const nextState = reservationSearchFiltersReducer(currentState, action);
+        expect(nextState).to.deep.equal(payload);
+      });
+
+      it('overrides previous values of same filters', () => {
+        const payload = {
+          start: '2016-12-15',
+          isFavorite: 'true',
+        };
+        const action = routeChangedAction(payload);
+        const currentState = {
+          start: '2016-12-12',
+          isFavorite: '',
+        };
+        const nextState = reservationSearchFiltersReducer(currentState, action);
+        expect(nextState).to.deep.equal({
+          start: '2016-12-15',
+          isFavorite: 'true',
+        });
+      });
+    });
+
+    describe('ENTER_OR_CHANGE_RESERVATION_SEARCH_PAGE', () => {
+      const routeChangedAction = createAction('ENTER_OR_CHANGE_RESERVATION_SEARCH_PAGE');
+
+      it('returns current state when payload has query parameters', () => {
+        const currentState = {
+          isFavorite: 'true',
+        };
+        const payload = {
+          query: {
+            is_favorite: '',
+          },
+        };
+        const action = routeChangedAction(payload);
+        const nextState = reservationSearchFiltersReducer(currentState, action);
+        expect(nextState).to.deep.equal(currentState);
+      });
+
+      it('returns initial state when payload has no query parameters', () => {
+        const currentState = {
+          isFavorite: 'true',
+        };
+        const payload = {
+          query: {},
+        };
+        const action = routeChangedAction(payload);
+        const nextState = reservationSearchFiltersReducer(currentState, action);
+        expect(nextState).to.deep.equal(getInitialState());
+      });
+    });
+  });
+});

--- a/app/state/reducers/reservationSearchResultsReducer.js
+++ b/app/state/reducers/reservationSearchResultsReducer.js
@@ -1,0 +1,12 @@
+import { handleActions } from 'redux-actions';
+
+import actionTypes from 'api/actionTypes';
+
+const initialState = [];
+
+export default handleActions({
+  [actionTypes.RESERVATIONS_GET_SUCCESS]: (state, action) => {
+    const reservationIds = Object.keys(action.payload.entities.reservations || {});
+    return reservationIds;
+  },
+}, initialState);

--- a/app/state/reducers/reservationSearchResultsReducer.spec.js
+++ b/app/state/reducers/reservationSearchResultsReducer.spec.js
@@ -1,0 +1,53 @@
+import keyBy from 'lodash/keyBy';
+import { expect } from 'chai';
+import { createAction } from 'redux-actions';
+
+import actionTypes from 'api/actionTypes';
+import reservationSearchResultsReducer from './reservationSearchResultsReducer';
+
+describe('state/reducers/reservationSearchResultsReducer', () => {
+  describe('initial state', () => {
+    function getInitialState() {
+      return reservationSearchResultsReducer(undefined, { type: 'NOOP' });
+    }
+
+    it('is an empty array', () => {
+      expect(getInitialState()).to.deep.equal([]);
+    });
+  });
+
+  describe('handling actions', () => {
+    describe('RESERVATIONS_GET_SUCCESS', () => {
+      const getReservationsSuccess = createAction(
+        actionTypes.RESERVATIONS_GET_SUCCESS,
+        reservations => ({
+          entities: {
+            reservations: keyBy(reservations, 'id'),
+          },
+        })
+      );
+      const reservations = [
+        { id: 'r-1', foo: 'bar' },
+        { id: 'r-2', foo: 'bar' },
+      ];
+
+      it('sets the given reservation ids to state', () => {
+        const action = getReservationsSuccess(reservations);
+        const currentState = [];
+        const expected = [reservations[0].id, reservations[1].id];
+        const nextState = reservationSearchResultsReducer(currentState, action);
+
+        expect(nextState).to.deep.equal(expected);
+      });
+
+      it('replaces the old ids in state', () => {
+        const action = getReservationsSuccess(reservations);
+        const currentState = ['r-99'];
+        const expected = [reservations[0].id, reservations[1].id];
+        const nextState = reservationSearchResultsReducer(currentState, action);
+
+        expect(nextState).to.deep.equal(expected);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Closes #123 

For some reservations there's no resource fetched. Clicking such reservation raises error. This is because the GET /reservations endpoint doesn't yet support `resource_group=kanslia` filter. When it starts supporting it those reservations will not be returned which solves the problem.

Todo:
- [x] Fix issue that search is not always done (It could be the same problem as #131)
