### PR TITLE
Hotfix/162 ie fixes

### DIFF
--- a/app/shared/date-picker/DatePicker.js
+++ b/app/shared/date-picker/DatePicker.js
@@ -25,6 +25,7 @@ function DatePicker(props) {
       dateFormat={pickerDateFormat}
       footer={false}
       onChange={date => props.onChange(formatDate(date))}
+      readOnly
       updateOnDateClick
       value={moment(props.value).format(pickerDateFormat)}
     >

--- a/app/shared/date-picker/date-picker.less
+++ b/app/shared/date-picker/date-picker.less
@@ -1,5 +1,12 @@
 .date-picker {
-
+  input {
+    // Reducing the input width to something smaller than what it is supposed
+    // to be displays correctly the calendar icon in IE and Firefox which would
+    // overflow otherwise.
+    // Width value won't be taken in account because date-picker display is flex
+    // and this element has a flex-grow, flex-shrink and flex-basis values.
+    width: 70%;
+  }
   // Selected value
   .react-date-picker__decade-view--theme-default,
   .react-date-picker__year-view--theme-default,

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react": "15.3.2",
     "react-addons-css-transition-group": "15.3.2",
     "react-bootstrap": "0.30.6",
-    "react-date-picker": "5.3.28",
+    "react-date-picker": "git://github.com/YoYuUm/react-date-picker.git#build-readonly",
     "react-document-title": "2.0.2",
     "react-dom": "15.3.2",
     "react-fontawesome": "1.5.0",


### PR DESCRIPTION
Closes #162

I didn't add the styles for removing the cross in inputs on IE, because apparently the input property "read-only" makes it not to be shown.

The selects are the same way than in the image, because that's apparently the way the look natively on ie10 and Edge.

This fixes an issue with the calendar icon in a wrong position on Edge and Firefox.