### PR TITLE
Fix sass in production configs

### DIFF
--- a/config/webpack.production.js
+++ b/config/webpack.production.js
@@ -36,8 +36,8 @@ module.exports = merge(common, {
         loader: ExtractTextPlugin.extract('style', 'css!postcss-loader'),
       },
       {
-        test: /\.less$/,
-        loader: ExtractTextPlugin.extract('style', 'css!postcss-loader!less'),
+        test: /\.scss$/,
+        loader: ExtractTextPlugin.extract('style', 'css!postcss-loader!sass'),
       },
     ],
   },


### PR DESCRIPTION
In develop `npm run build` fails, in this branch it works again. Currently the staging server doesn't work because of that.