### PR TITLE
Upgrade redux-api-middleware to fix bug in Safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "react-sticky-el": "1.0.3",
     "redux": "3.6.0",
     "redux-actions": "0.13.0",
-    "redux-api-middleware": "1.0.2",
+    "redux-api-middleware": "1.0.3",
     "redux-form": "6.6.1",
     "reselect": "2.5.4",
     "sass-loader": "4.1.1",


### PR DESCRIPTION
AUTH_GET request did not work but redux-api-middleware 1.0.3 has fixed the issue.

Closes #188 