### PR TITLE
Raise page_size to get all resource / unit elements

### DIFF
--- a/app/api/actions/resources.js
+++ b/app/api/actions/resources.js
@@ -21,7 +21,7 @@ function fetchResource(id, params = {}) {
 function fetchResources(params = {}, times = true, meta) {
   const defaultParams = {
     resource_group: 'kanslia',
-    pageSize: 100,
+    pageSize: 1000,
   };
   const paramsWithTimes = times ? getParamsWithTimes(params) : params;
   return createApiAction({

--- a/app/api/actions/resources.spec.js
+++ b/app/api/actions/resources.spec.js
@@ -99,7 +99,7 @@ describe('api/actions/resources', () => {
     describe('without times', () => {
       const params = {
         resource_group: 'kanslia',
-        pageSize: 100,
+        pageSize: 1000,
         some: 'arg',
       };
       createApiTest({

--- a/app/api/actions/units.js
+++ b/app/api/actions/units.js
@@ -4,7 +4,7 @@ import { createApiAction } from './utils';
 function fetchUnits() {
   return createApiAction({
     endpoint: 'unit',
-    params: { pageSize: 100, resource_group: 'kanslia' },
+    params: { pageSize: 1000, resource_group: 'kanslia' },
     method: 'GET',
     type: 'UNITS',
     options: { schema: schemas.paginatedUnitsSchema },

--- a/app/api/actions/units.spec.js
+++ b/app/api/actions/units.spec.js
@@ -11,7 +11,7 @@ describe('api/actions/units', () => {
       args: [],
       tests: {
         method: 'GET',
-        endpoint: buildAPIUrl('unit', { pageSize: 100, resource_group: 'kanslia' }),
+        endpoint: buildAPIUrl('unit', { pageSize: 1000, resource_group: 'kanslia' }),
         request: {
           type: types.UNITS_GET_REQUEST,
         },


### PR DESCRIPTION
Currently frontend only fetches the first 100 elements which leaves out resources / units which causes the `Tuntematon tila` error in the frontend. This will fix the issue until more permanent solution is implemented in the backend side.